### PR TITLE
[update] コレクション関連のリファクタリングを行う。

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -43,7 +43,7 @@ class Collection implements ArrayAccess, IArrayable, ICollection, IReadonlyColle
      */
     public function tryGet(int|string $key, mixed $default = null) : mixed
     {
-        if(!$this->existsKey($key))
+        if(!$this->containsKey($key))
         {
             return $default;
         }
@@ -61,7 +61,7 @@ class Collection implements ArrayAccess, IArrayable, ICollection, IReadonlyColle
      */
     public function get(int|string $key) : mixed
     {
-        if(!$this->existsKey($key))
+        if(!$this->containsKey($key))
         {
             throw new ElementNotFoundException("Key[{$key}] is not found in collection.");
         }
@@ -79,7 +79,7 @@ class Collection implements ArrayAccess, IArrayable, ICollection, IReadonlyColle
     {
         if($key !== null)
         {
-            if($this->existsKey($key))
+            if($this->containsKey($key))
             {
                 return false;
             }
@@ -107,7 +107,7 @@ class Collection implements ArrayAccess, IArrayable, ICollection, IReadonlyColle
     {
         if($key !== null)
         {
-            if($this->existsKey($key))
+            if($this->containsKey($key))
             {
                 throw new DuplicateElementException("Duplicate key[{$key}] in collection.");
             }
@@ -131,7 +131,7 @@ class Collection implements ArrayAccess, IArrayable, ICollection, IReadonlyColle
      */
     public function tryUpdate(int|string $key, mixed $value) : bool
     {
-        if(!$this->existsKey($key))
+        if(!$this->containsKey($key))
         {
             return false;
         }
@@ -151,7 +151,7 @@ class Collection implements ArrayAccess, IArrayable, ICollection, IReadonlyColle
      */
     public function update(int|string $key, mixed $value) : static
     {
-        if(!$this->existsKey($key))
+        if(!$this->containsKey($key))
         {
             throw new ElementNotFoundException("Key[{$key}] is not found in collection.");
         }
@@ -181,7 +181,7 @@ class Collection implements ArrayAccess, IArrayable, ICollection, IReadonlyColle
      */
     public function tryRemove(int|string $key) : bool
     {
-        if(!$this->existsKey($key))
+        if(!$this->containsKey($key))
         {
             return false;
         }
@@ -201,7 +201,7 @@ class Collection implements ArrayAccess, IArrayable, ICollection, IReadonlyColle
      */
     public function remove(int|string $key) : static
     {
-        if(!$this->existsKey($key))
+        if(!$this->containsKey($key))
         {
             throw new ElementNotFoundException("Key[{$key}] is not found in collection.");
         }
@@ -230,7 +230,7 @@ class Collection implements ArrayAccess, IArrayable, ICollection, IReadonlyColle
     /**
      * @inheritDoc
      */
-    public function existsKey(int|string $key) : bool
+    public function containsKey(int|string $key) : bool
     {
         return key_exists($key, (array)$this->elms);
     }
@@ -241,7 +241,7 @@ class Collection implements ArrayAccess, IArrayable, ICollection, IReadonlyColle
     /**
      * @inheritDoc
      */
-    public function existsValue(mixed $value) : bool
+    public function containsValue(mixed $value) : bool
     {
         return in_array($value, (array)$this->elms, true);
     }
@@ -341,7 +341,7 @@ class Collection implements ArrayAccess, IArrayable, ICollection, IReadonlyColle
             throw new InvalidArgumentException('キーの型['.gettype($offset).']が不正です。');
         }
 
-        return $this->existsKey($offset);
+        return $this->containsKey($offset);
     }
 
 

--- a/src/Collection/ICollection.php
+++ b/src/Collection/ICollection.php
@@ -113,7 +113,7 @@ interface ICollection extends Countable, IteratorAggregate
      * @param int|string $key
      * @return bool
      */
-    public function existsKey(int|string $key) : bool;
+    public function containsKey(int|string $key) : bool;
 
 
     /**
@@ -122,5 +122,5 @@ interface ICollection extends Countable, IteratorAggregate
      * @param mixed $value
      * @return bool
      */
-    public function existsValue(mixed $value) : bool;
+    public function containsValue(mixed $value) : bool;
 }

--- a/src/Collection/IReadonlyCollection.php
+++ b/src/Collection/IReadonlyCollection.php
@@ -13,10 +13,38 @@ interface IReadonlyCollection extends Countable, IteratorAggregate
     // 抽象関数
     // ================================================================
     /**
+     * 要素の取得を試みる。
+     *
+     * @param int|string $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public function tryGet(int|string $key, mixed $default = null) : mixed;
+
+
+    /**
      * 要素を取得する。
      *
      * @param int|string $key
      * @return mixed
      */
     public function get(int|string $key) : mixed;
+
+
+    /**
+     * 特定のキーが含まれるか判定する。
+     *
+     * @param int|string $key
+     * @return bool
+     */
+    public function containsKey(int|string $key) : bool;
+
+
+    /**
+     * 特定の値が含まれるか判定する。
+     *
+     * @param mixed $value
+     * @return bool
+     */
+    public function containsValue(mixed $value) : bool;
 }

--- a/tests/Collection/CollectionTest.php
+++ b/tests/Collection/CollectionTest.php
@@ -190,7 +190,7 @@ final class CollectionTest extends TestCase
         // ::remove()メソッドのテスト
         $collection->remove(0);
         $this->assertCount(--$expectSize, $collection);
-        $this->assertFalse($collection->existsKey('0'));
+        $this->assertFalse($collection->containsKey('0'));
 
 
         // ::tryRemove()メソッドのテスト
@@ -198,7 +198,7 @@ final class CollectionTest extends TestCase
 
         $collection->tryRemove(1);
         $this->assertCount(--$expectSize, $collection);
-        $this->assertFalse($collection->existsKey('1'));
+        $this->assertFalse($collection->containsKey('1'));
 
 
         // 配列アクセスのテスト
@@ -207,7 +207,7 @@ final class CollectionTest extends TestCase
 
         unset($collection[2]);
         $this->assertCount(--$expectSize, $collection);
-        $this->assertFalse($collection->existsKey('2'));
+        $this->assertFalse($collection->containsKey('2'));
     }
 
 


### PR DESCRIPTION
## 概要
[Jp\Skud\Collection\Collection]の関連クラスに以下の修正を行う。
- Collection::exits*()系のメソッド名をContains*()に変更する。
- ICollectionとIReadonlyCollection間の差異を減ずる。