### PR TITLE
[update] 命名規則に従っていないテストクラス名を修正する。

### DIFF
--- a/tests/IO/StreamTest.php
+++ b/tests/IO/StreamTest.php
@@ -8,9 +8,9 @@ use Jp\Skud\Sdl\IO\Stream;
 use PHPUnit\Framework\TestCase;
 
 /**
- * [Jp\Skud\Sdl\IO\FileStream]の単体テストクラス
+ * [Jp\Skud\Sdl\IO\Stream]の単体テストクラス
  */
-final class FileStreamTest extends TestCase
+final class StreamTest extends TestCase
 {
     // ================================================================
     // 定数


### PR DESCRIPTION
## 概要
以下のテストクラスが、命名規則に準じていない問題を修正する。
```
- Jp\Skud\SdlTest\IO\FileStreamTest
+ Jp\Skud\SdlTest\IO\StreamTest 
```